### PR TITLE
fix: normalize repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "ynoki10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ynoki10/md2bl.git"
+    "url": "git+https://github.com/ynoki10/md2bl.git"
   },
   "homepage": "https://github.com/ynoki10/md2bl#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- `npm pkg fix` で指摘された `repository.url` を `git+https://` 形式に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)