### PR TITLE
chore: update package-lock.json to reflect package rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "md2bklog",
+  "name": "md2bl",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "md2bklog",
+      "name": "md2bl",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -15,7 +15,7 @@
         "unified": "^11.0.5"
       },
       "bin": {
-        "md2bklog": "dist/index.js"
+        "md2bl": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- パッケージリネーム (`md2bklog` → `md2bl`) に伴う `package-lock.json` の差分をコミット

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)