### PR TITLE
fix: release-please で PAT を使用し CI トリガーを有効化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

- release-please の token を `GITHUB_TOKEN` から `RELEASE_PLEASE_TOKEN` (PAT) に変更
- `GITHUB_TOKEN` で作成された PR は GitHub の制約により他のワークフローをトリガーしないため、required status checks が永遠に通らずマージできない問題を解決

## 背景

PR #23 (release v0.1.1) で CI が走らずマージできない状態だった。
この修正を main にマージ後、release-please が PAT で PR #23 を更新することで CI がトリガーされるようになる。

## Test plan

- [x] リポジトリ Secret に `RELEASE_PLEASE_TOKEN` (Fine-grained PAT) が登録済みであること
- [ ] この PR マージ後、release-please が PR #23 を更新し CI が走ることを確認
- [ ] CI pass 後 PR #23 をマージしてリリース完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)