### PR TITLE
chore: npm publish を Trusted Publishing に移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,3 @@ jobs:
 
       - run: npm publish --provenance --access public
         if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- npm publish の認証を `NPM_TOKEN` (Granular Access Token) から **Trusted Publishing** (OIDC) に移行
- `NODE_AUTH_TOKEN` 環境変数を削除し、GitHub Actions の OIDC トークンで直接 npm に認証

## 背景

PR #23 マージ時に `npm publish` が 2FA (OTP) を要求して失敗した。
Trusted Publishing は OIDC ベースの認証で、トークン管理が不要かつ 2FA の影響を受けない。

## 前提条件

npmjs.com で Trusted Publishing の設定が必要:
- パッケージ `md2bl` → Settings → Publishing access → Trusted publishing
- Repository owner: `ynoki10`, Repository name: `md2bl`, Workflow: `release.yml`

## Test plan

- [x] npmjs.com で Trusted Publishing を設定済み
- [ ] マージ後、release-please が新しいリリース PR を作成し、マージ時に `npm publish` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)