### PR TITLE
fix: パッケージ説明文を改善

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 
 Markdown を [Backlog 記法](https://support-ja.backlog.com/hc/ja/articles/360035641594-%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E6%95%B4%E5%BD%A2%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB-Backlog%E8%A8%98%E6%B3%95) に変換する CLI ツール。
 
-Markdown を Backlog の課題・Wiki・PR にそのまま貼れる形式へ変換します。stdin/stdout のパイプに対応しているため、Shell スクリプトや各種ツールに組み込みやすいのが特徴です。
+Markdown を Backlog記法を利用しているBacklogプロジェクト の課題・Wiki・PR にそのまま貼れる形式へ変換します。stdin/stdout のパイプに対応しているため、Shell スクリプトや各種ツールに組み込みやすいのが特徴です。
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ English | [日本語](./README.ja.md)
 
 A CLI tool to convert Markdown to [Backlog notation](https://support.nulab.com/hc/en-us/articles/8775439725721-Backlog-text-formatting-rules).
 
-Converts Markdown into a format that can be pasted directly into Backlog issues, Wikis, and PRs. Supports stdin/stdout piping, making it easy to integrate into shell scripts and other tools.
+Converts Markdown into a format that can be pasted directly into issues, Wikis, and PRs in Backlog projects that use Backlog notation. Supports stdin/stdout piping, making it easy to integrate into shell scripts and other tools.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "md2bl",
   "version": "0.1.1",
-  "description": "Convert Markdown to Backlog notation",
+  "description": "A CLI tool to convert Markdown to Backlog notation",
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- `package.json` の description に CLI ツールであることを明記
- README.md / README.ja.md の説明文で Backlog記法を利用している Backlog プロジェクト向けであることを明確化

## 背景

v0.1.1 リリースのために `fix:` コミットが必要。合わせて説明文の改善を行う。

## Test plan

- [x] CI pass
- [ ] マージ後、release-please がリリース PR を作成すること
- [ ] リリース PR マージ後、Trusted Publishing で npm publish が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)