### PR TITLE
chore: Trusted Publishing の設定を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@latest
+        if: ${{ steps.release.outputs.release_created }}
 
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

- `actions/setup-node` から `registry-url` を削除（OIDC と競合する `.npmrc` 生成を防止）
- `npm install -g npm@latest` ステップを追加（Trusted Publishing に npm 11.5.1+ が必要）

## 背景

PR #31 マージ時の npm publish が E404 で失敗。原因:
1. `registry-url` により `.npmrc` に `${NODE_AUTH_TOKEN}` が書き込まれ、空トークンで認証を試みて OIDC にフォールバックしない
2. Node 22 バンドルの npm 10.x は Trusted Publishing 非対応

## Test plan

- [ ] CI pass
- [ ] マージ後、次のリリースサイクルで npm publish が Trusted Publishing で成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)