### PR TITLE
fix: package.json に engines フィールドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "converter",
     "cli"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "license": "MIT",
   "author": "ynoki10",
   "repository": {


### PR DESCRIPTION
## Summary

- `package.json` に `engines` フィールドを追加し、Node.js 18 以上が必要であることを明記

## 背景

README には「Node.js 18 以上が必要」と記載済みだが、`package.json` に反映されていなかった。

## Test plan

- [ ] CI pass
- [ ] マージ後、release-please がリリース PR を作成すること
- [ ] リリース PR マージ後、Trusted Publishing で npm publish が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)