### PR TITLE
docs: リリースプロセスに認証方式の説明を追加

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,6 +9,11 @@ release-please が Release PR を自動作成・更新し、Release PR をマー
 2. release-please が「Release PR」を自動作成・更新（CHANGELOG・package.json のバージョンを更新）
 3. Release PR をマージ → Git タグ・GitHub Release・npm publish が自動実行
 
+## 認証・トークン
+
+- **release-please**: `RELEASE_PLEASE_TOKEN`（GitHub Fine-grained PAT）を使用。`GITHUB_TOKEN` では PR 作成時に CI がトリガーされないため。
+- **npm publish**: [Trusted Publishing](https://docs.npmjs.com/trusted-publishers/)（OIDC）を使用。npm トークン不要。npmjs.com 側でリポジトリ・ワークフローを登録済み。
+
 ## バージョニング規則
 
 | コミット種別 | バージョン変更 |


### PR DESCRIPTION
## Summary

- `docs/release-process.md` に認証・トークンセクションを追加
- release-please の PAT 使用理由と npm Trusted Publishing (OIDC) について記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)