### PR TITLE
feat: add programmatic API support for library usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,9 +4,9 @@
 
 [![npm version](https://badge.fury.io/js/md2bl.svg)](https://www.npmjs.com/package/md2bl)
 
-Markdown を [Backlog 記法](https://support-ja.backlog.com/hc/ja/articles/360035641594-%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E6%95%B4%E5%BD%A2%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB-Backlog%E8%A8%98%E6%B3%95) に変換する CLI ツール。
+Markdown を [Backlog 記法](https://support-ja.backlog.com/hc/ja/articles/360035641594-%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E6%95%B4%E5%BD%A2%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB-Backlog%E8%A8%98%E6%B3%95) に変換する CLI ツール & ライブラリ。
 
-Markdown を Backlog記法を利用しているBacklogプロジェクト の課題・Wiki・PR にそのまま貼れる形式へ変換します。stdin/stdout のパイプに対応しているため、Shell スクリプトや各種ツールに組み込みやすいのが特徴です。
+Markdown を Backlog記法を利用しているBacklogプロジェクト の課題・Wiki・PR にそのまま貼れる形式へ変換します。stdin/stdout のパイプに対応しているため、Shell スクリプトや各種ツールに組み込みやすいのが特徴です。Node.js/TypeScript プロジェクトからライブラリとしても利用できます。
 
 ## インストール
 
@@ -17,6 +17,22 @@ npm install -g md2bl
 ```
 
 ## 使い方
+
+### ライブラリとして使う
+
+Node.js/TypeScript プロジェクトからプログラムで利用できます:
+
+```sh
+npm install md2bl
+```
+
+```ts
+import { convert } from 'md2bl';
+
+const backlog = convert('# Hello **world**');
+console.log(backlog);
+// => * Hello ''world''
+```
 
 ### ファイルを変換する
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ English | [日本語](./README.ja.md)
 
 [![npm version](https://badge.fury.io/js/md2bl.svg)](https://www.npmjs.com/package/md2bl)
 
-A CLI tool to convert Markdown to [Backlog notation](https://support.nulab.com/hc/en-us/articles/8775439725721-Backlog-text-formatting-rules).
+A CLI tool and library to convert Markdown to [Backlog notation](https://support.nulab.com/hc/en-us/articles/8775439725721-Backlog-text-formatting-rules).
 
-Converts Markdown into a format that can be pasted directly into issues, Wikis, and PRs in Backlog projects that use Backlog notation. Supports stdin/stdout piping, making it easy to integrate into shell scripts and other tools.
+Converts Markdown into a format that can be pasted directly into issues, Wikis, and PRs in Backlog projects that use Backlog notation. Supports stdin/stdout piping, making it easy to integrate into shell scripts and other tools. Also usable as a library in Node.js/TypeScript projects.
 
 ## Installation
 
@@ -17,6 +17,22 @@ npm install -g md2bl
 ```
 
 ## Usage
+
+### Programmatic Usage
+
+You can also use md2bl as a library in your Node.js/TypeScript project:
+
+```sh
+npm install md2bl
+```
+
+```ts
+import { convert } from 'md2bl';
+
+const backlog = convert('# Hello **world**');
+console.log(backlog);
+// => * Hello ''world''
+```
 
 ### Convert a file
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,18 @@
 {
   "name": "md2bl",
   "version": "0.1.3",
-  "description": "A CLI tool to convert Markdown to Backlog notation",
+  "description": "A CLI tool and library to convert Markdown to Backlog notation",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/lib.d.ts",
+        "default": "./dist/lib.js"
+      }
+    }
+  },
   "bin": {
     "md2bl": "dist/index.js"
   },
@@ -17,7 +26,8 @@
     "markdown",
     "backlog",
     "converter",
-    "cli"
+    "cli",
+    "library"
   ],
   "engines": {
     "node": ">=18"

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -80,8 +80,8 @@ export function compileNode(node: Node, ctx: CompileContext = makeContext()): st
       // フロントマターはそのまま出力
       return `---\n${(node as unknown as { value: string }).value}\n---`;
     default:
-      process.stderr.write(
-        `[md2bl] WARNING: unsupported node type "${node.type}" — skipped\n`
+      console.warn(
+        `[md2bl] WARNING: unsupported node type "${node.type}" — skipped`
       );
       return "";
   }
@@ -205,15 +205,15 @@ function compileListItem(node: ListItem, ctx: CompileContext): string {
 }
 
 function compileImage(node: Image): string {
-  process.stderr.write(
-    `[md2bl] WARNING: image "${node.url}" is not supported in Backlog notation — skipped\n`
+  console.warn(
+    `[md2bl] WARNING: image "${node.url}" is not supported in Backlog notation — skipped`
   );
   return "";
 }
 
 function compileHtml(node: Html): string {
-  process.stderr.write(
-    `[md2bl] WARNING: raw HTML is not supported in Backlog notation — skipped\n`
+  console.warn(
+    `[md2bl] WARNING: raw HTML is not supported in Backlog notation — skipped`
   );
   return "";
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,1 @@
+export { convert } from './converter.js';


### PR DESCRIPTION
## Summary

- `import { convert } from 'md2bl'` でJS/TSプロジェクトからプログラマティックに利用可能に
- `src/lib.ts` をライブラリエントリーポイントとして新規作成し、`package.json` に `exports` / `types` フィールドを追加
- `compiler.ts` の `process.stderr.write` を `console.warn` に変更し、ランタイム互換性を向上

## Test plan

- [x] `npm run build` で `dist/lib.js` / `dist/lib.d.ts` が生成されること
- [x] `npm test` で既存テスト全32件パス
- [x] `node -e "import { convert } from './dist/lib.js'; console.log(convert('# Hello **world**'));"` で正常動作確認
- [ ] CLI (`npx md2bl input.md`) が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)