### PR TITLE
docs: add "Why md2bl?" section to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,14 @@ Markdown を [Backlog 記法](https://support-ja.backlog.com/hc/ja/articles/3600
 
 Markdown を Backlog記法を利用しているBacklogプロジェクト の課題・Wiki・PR にそのまま貼れる形式へ変換します。stdin/stdout のパイプに対応しているため、Shell スクリプトや各種ツールに組み込みやすいのが特徴です。
 
+## なぜ md2bl？
+
+ChatGPT や Gemini などの AI ツールの出力は Markdown ですが、Backlog 記法を使っているスペースにそのまま貼ると書式が崩れます。
+
+AI に Backlog 記法を教えることもできますが、トークンの無駄遣いになり出力の汎用性も下がります。AI には Markdown で出力させ、あとから機械的に変換するほうが合理的です。
+
+> **Note:** 2025年5月より、Backlog は新規スペースでは Markdown（GFM）がデフォルトになりましたが、既存スペースの多くは引き続き Backlog 記法を使用しています。
+
 ## インストール
 
 Node.js 18 以上が必要です。

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A CLI tool to convert Markdown to [Backlog notation](https://support.nulab.com/h
 
 Converts Markdown into a format that can be pasted directly into issues, Wikis, and PRs in Backlog projects that use Backlog notation. Supports stdin/stdout piping, making it easy to integrate into shell scripts and other tools.
 
+## Why md2bl?
+
+AI tools like ChatGPT and Gemini output Markdown, but many Backlog spaces still use Backlog notation. Pasting AI-generated Markdown into these spaces breaks formatting.
+
+Rather than teaching AI tools Backlog notation (which wastes tokens and limits output versatility), it's simpler to let AI write standard Markdown and convert it afterward — the conversion is purely mechanical.
+
+> **Note:** Since May 2025, Backlog defaults to Markdown (GFM) for new spaces, but many existing spaces continue to use Backlog notation.
+
 ## Installation
 
 Requires Node.js 18 or later.


### PR DESCRIPTION
## Summary

- README.md / README.ja.md に「Why md2bl?」セクションを追加
- AIツールの出力がMarkdownであること、Backlog記法スペースでの書式崩れ、変換アプローチの妥当性を説明
- 新規スペースのGFMデフォルト化についてのNoteも記載

## Test plan

- [ ] README.md のプレビューで「Why md2bl?」セクションの表示を確認
- [ ] README.ja.md のプレビューで「なぜ md2bl？」セクションの表示を確認
- [ ] セクション構成（Why → Installation → Usage）の流れが自然であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)