### PR TITLE
docs: add notation gaps reference and alternatives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,5 @@ cat input.md | node dist/index.js
 - PR 作成手順 → `.claude/skills/pr-workflow.md`
 - 変換ルール早見表 → `docs/conversion-rules.md`
 - リリース手順 → `docs/release-process.md`
+- Backlog記法との差分・対象外項目 → `docs/backlog-notation-gaps.md`
+- 類似ツール比較 → `docs/alternatives.md`

--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,0 +1,12 @@
+# Alternative Tools
+
+md2bl 以外にも Markdown → Backlog記法の変換ツールが存在する。
+
+| ツール | 言語/形態 | 特徴 | 備考 |
+|--------|-----------|------|------|
+| [md2bg](https://github.com/37108/md2bg) | Node.js | AST変換 | 対応nodeが限定的 |
+| [md2backlog](https://github.com/yandod/md2backlog) | Ruby | kramdown利用 | 未対応書式多い |
+| [md2bl (Perl)](https://github.com/newnakashima/md2bl) | Perl | 正規表現ベース | 名前が衝突（別プロジェクト） |
+| [obsidian-backlog-converter](https://github.com/junpei-takagi/obsidian-backlog-converter) | Obsidian plugin | 双方向変換 | 2025年8月公開、機能充実 |
+
+md2bl（本プロジェクト）の差別化: CLI + ライブラリ両対応、GFM 完全サポート、活発なメンテナンス。

--- a/docs/backlog-notation-gaps.md
+++ b/docs/backlog-notation-gaps.md
@@ -1,0 +1,56 @@
+# Backlog記法との差分・対象外項目
+
+Backlog公式ヘルプ（[Backlog記法](https://support-ja.backlog.com/hc/ja/articles/360035641594)・[Markdown記法](https://support-ja.backlog.com/hc/ja/articles/360036145833)）と md2bl の実装を突き合わせた結果をまとめる。
+
+調査日: 2026-03-21
+
+## 対応不要な項目
+
+### Markdown 側に対応する概念がないもの
+
+| Backlog記法 | 説明 | 理由 |
+|---|---|---|
+| `&color(red) { テキスト }` | 文字色指定 | Markdown に色指定の構文がない |
+| `&color(#fff, #8abe00) { テキスト }` | 背景色指定 | 同上 |
+
+### Backlog 環境依存の機能
+
+| 記法 | 説明 | md2bl での扱い |
+|---|---|---|
+| `BLG-104` / `[[BLG-87]]` | 課題へのリンク | テキストノードとしてそのまま出力される。Backlog UI が自動リンク化する |
+| `[[Home]]` | Wiki ページリンク | 同上 |
+| `#rev(11)` / `#rev(app:abcdefg)` | SVN/Git リビジョンリンク | 入力に含まれていればそのまま出力される |
+| `#attach(file.zip:11)` | Wiki 添付ファイルリンク | 入力に含まれていればそのまま出力される |
+| `#contents` / `[toc]` | 目次自動生成 | 対応予定: [#41](https://github.com/ynoki10/md2bl/issues/41) で `[toc]` → `#contents` 変換を実装予定 |
+
+### Backlog記法に対応する出力構文がないもの
+
+| Markdown 入力 | 説明 | md2bl での扱い |
+|---|---|---|
+| 定義リスト (`term\n: definition`) | PHP Markdown Extra 拡張 | GFM 入力に現れない。Backlog記法に対応構文なし |
+| `<details>` / `<summary>` | 折りたたみ表示 | Backlog Markdown モードのみの機能。Backlog記法に対応構文なし。`html` ノードとして警告+スキップ |
+| テーブルのセル結合 (`\|\|`) | Backlog 独自 Markdown 拡張 | 標準 GFM 入力に現れない |
+
+### 対応予定のもの
+
+| Backlog記法 | 説明 | md2bl での扱い |
+|---|---|---|
+| `{quote}...{/quote}` | ブロック引用 | 対応予定: [#42](https://github.com/ynoki10/md2bl/issues/42) で `quoteStyle` オプションを導入予定。デフォルト `auto`（1行 → `>`、複数行 → `{quote}`） |
+
+## コード言語サポートについて
+
+Backlog記法の `{code:}` マクロがサポートする言語は **`java` と `cs`（C#）の2つのみ**。
+
+- `{code:java}` → Eclipse 標準文字色で表示
+- `{code:cs}` → Visual C# .NET 標準文字色で表示
+- `{code}` → 汎用的な色付け
+
+Markdown の ` ```lang ` で指定された言語が `java` / `cs` 以外の場合は `{code}` にフォールバックする。
+
+参考: [Backlog Enterprise コードマクロ](https://backlog.com/ja/enterprise-help/userguide/userguide195/)
+
+## 画像表示について
+
+Backlog記法の `#image()` は公式ヘルプでは Wiki 添付ファイル ID での使用のみ記載されているが、`#image(URL)` で外部 URL 画像も表示可能。
+
+参考: [Backlogで添付画像やGyazoの画像を表示する方法](https://qiita.com/p_on_ro/items/1d1f2f6aed0484a80cd1)


### PR DESCRIPTION
## Summary

- `docs/backlog-notation-gaps.md`: Backlog記法との差分・対象外項目のリファレンスを追加
- `docs/alternatives.md`: 類似ツールとの比較表を追加
- `CLAUDE.md`: 関連ドキュメントの所在にリンクを追加

## Test plan

- [ ] `docs/backlog-notation-gaps.md` の内容が正確か確認
- [ ] `docs/alternatives.md` のリンクが有効か確認
- [ ] `CLAUDE.md` の参照が正しいか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)