### PR TITLE
chore: ブランチ削除の運用ルールを追加

### DIFF
--- a/.claude/rules/branch-and-commit.md
+++ b/.claude/rules/branch-and-commit.md
@@ -27,3 +27,12 @@ refactor: リファクタリング
 ```
 
 例: `feat: add support for definition lists`
+
+## ブランチの削除
+
+- GitHub の「Automatically delete head branches」が有効化済み。PR マージ時にリモートブランチは自動削除される
+- PR マージ後、ローカルブランチも削除する:
+  ```
+  git branch -d <branch-name>
+  ```
+- worktree 内で作業していた場合は worktree も先に削除する（`worktree-lifecycle.md` 参照）


### PR DESCRIPTION
## Summary
- GitHub の「Automatically delete head branches」設定を有効化済み
- `.claude/rules/branch-and-commit.md` にブランチ削除の運用ルールを追記
- マージ済みリモートブランチ16本を削除済み

## Test plan
- [x] `.claude/rules/branch-and-commit.md` の内容が正しいことを確認
- [x] `worktree-lifecycle.md` との整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)