### PR TITLE
docs: backlog-notation-gaps.md の対応方針を更新

### DIFF
--- a/docs/backlog-notation-gaps.md
+++ b/docs/backlog-notation-gaps.md
@@ -19,9 +19,8 @@ Backlog公式ヘルプ（[Backlog記法](https://support-ja.backlog.com/hc/ja/ar
 |---|---|---|
 | `BLG-104` / `[[BLG-87]]` | 課題へのリンク | テキストノードとしてそのまま出力される。Backlog UI が自動リンク化する |
 | `[[Home]]` | Wiki ページリンク | 同上 |
-| `#rev(11)` / `#rev(app:abcdefg)` | SVN/Git リビジョンリンク | 入力に含まれていればそのまま出力される |
-| `#attach(file.zip:11)` | Wiki 添付ファイルリンク | 入力に含まれていればそのまま出力される |
-| `#contents` / `[toc]` | 目次自動生成 | 対応予定: [#41](https://github.com/ynoki10/md2bl/issues/41) で `[toc]` → `#contents` 変換を実装予定 |
+| `#rev(11)` / `#rev(app:abcdefg)` | SVN/Git リビジョンリンク | 同上 |
+| `#attach(file.zip:11)` | Wiki 添付ファイルリンク | 同上 |
 
 ### Backlog記法に対応する出力構文がないもの
 
@@ -29,10 +28,11 @@ Backlog公式ヘルプ（[Backlog記法](https://support-ja.backlog.com/hc/ja/ar
 |---|---|---|
 | テーブルのセル結合 (`\|\|`) | Backlog 独自 Markdown 拡張 | 標準 GFM 入力に現れない。GFM パーサは `\|\|` を空セルとして解釈し、空セルがそのまま出力される。対応不要 |
 
-### 対応予定のもの
+## 対応予定のもの
 
-| Markdown 入力 | 説明 | md2bl での扱い |
+| 記法 | 説明 | md2bl での扱い |
 |---|---|---|
+| `#contents` / `[toc]` | 目次自動生成 | 対応予定: [#41](https://github.com/ynoki10/md2bl/issues/41) で `[toc]` → `#contents` 変換を実装予定 |
 | `> blockquote` | ブロック引用 | 対応予定: [#42](https://github.com/ynoki10/md2bl/issues/42) で `quoteStyle` オプションを導入予定。デフォルト `auto`（1行 → `>`、複数行 → `{quote}`） |
 | 定義リスト (`term\n: definition`) | PHP Markdown Extra 拡張 | 対応予定: [#47](https://github.com/ynoki10/md2bl/issues/47) で妥当なBacklog記法へのフォールバック変換を実装予定 |
 | `<details>` / `<summary>` | 折りたたみ表示 | 対応予定: [#48](https://github.com/ynoki10/md2bl/issues/48) で妥当なBacklog記法へのフォールバック変換を実装予定 |


### PR DESCRIPTION
## Summary

- 定義リスト → 「対応予定のもの」に移動、Issue #47 へのリンクを追加
- `<details>` / `<summary>` → 「対応予定のもの」に移動、Issue #48 へのリンクを追加
- テーブルのセル結合 (`||`) → 調査の結果、GFM パーサが空セルとして解釈し対応不要であることを明記
- 「対応予定のもの」セクションを `##` レベルに昇格し、「対応不要な項目」の外に配置
- `#contents` を「Backlog 環境依存の機能」から「対応予定のもの」に移動
- `#rev` / `#attach` の説明を「同上」に統一
- `{quote}...{/quote}` → `> blockquote` に修正し、列名との整合性を確保

## Test plan

- [ ] `docs/backlog-notation-gaps.md` の表記・リンクが正しいことを確認
- [ ] Issue #41, #42, #47, #48 へのリンクが有効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)