### PR TITLE
chore: force release 0.4.2 via release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "packages": {
     ".": {
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "release-as": "0.4.2"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `release-please-config.json` に `release-as: "0.4.2"` を追加して強制リリース
- v0.4.0/v0.4.1 は npm publish が OIDC 未対応で失敗していたため、修正後の初リリースとして必要

## Note
リリース後に `release-as` を削除するフォローアップが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)