### PR TITLE
fix: use OIDC trusted publishing for npm publish

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "packages": {
     ".": {
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "release-as": "0.4.2"
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- `release.yml` から `registry-url` と `NODE_AUTH_TOKEN` を削除し、OIDC trusted publishing に委譲
- `release-please-config.json` から不要な `release-as` を削除

## 背景
npm 側で「Require 2FA and disallow tokens」が有効なため、トークン認証では publish できない。
Node 24 (npm 11.x) の OIDC 対応により、トークン不要で publish 可能になった。

## Test plan
- [ ] CI pass
- [ ] マージ後 release-please が 0.4.2 の PR を自動作成
- [ ] release-please PR マージで OIDC publish 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)