### PR TITLE
docs: 未対応ノードの欠落と絵文字の制約を backlog-notation-gaps に追記

### DIFF
--- a/docs/backlog-notation-gaps.md
+++ b/docs/backlog-notation-gaps.md
@@ -51,6 +51,44 @@ Backlog公式ヘルプ（[Backlog記法](https://support-ja.backlog.com/hc/ja/ar
 
 Backlog記法にはテーブルセル内のパイプをエスケープする構文がないため、md2bl 側では回避できない。
 
+### 未対応ノードは警告つきで本文から除去される
+
+（2026-07-31 / md2bl 0.4.2 時点）
+
+変換できないノードに当たると stderr に警告を出し、**stdout の本文からはそのノードを取り除く**。stdout をそのまま Backlog に投稿する使い方では、投稿後のプレビューで初めて欠落に気づくことになる。
+
+現在このパスに入る入力:
+
+| 入力 | 警告 | 関連 issue |
+|---|---|---|
+| プレーンテキスト中の `<...>`（例: `?type=<key>`） | `raw HTML is not supported...` | [#110](https://github.com/ynoki10/md2bl/issues/110) |
+| HTML ブロック（例: `<div>本文</div>`）。タグだけでなく内側のテキストも失われる | 同上 | [#115](https://github.com/ynoki10/md2bl/issues/115) |
+| `<br>`。GFM のテーブルセル内は生の改行を書けないため、セル内改行の表現手段が無くなる | 同上 | [#112](https://github.com/ynoki10/md2bl/issues/112) |
+| 参照リンク・参照画像 (`[text][ref]`) と定義行。リンクテキスト・alt ごと失われる | `unsupported node type "linkReference"` / `"imageReference"` / `"definition"` | [#111](https://github.com/ynoki10/md2bl/issues/111) |
+| 脚注 (`[^1]`) と定義。注記の本文も失われる | `unsupported node type "footnoteReference"` / `"footnoteDefinition"` | [#113](https://github.com/ynoki10/md2bl/issues/113) |
+
+警告に入力の位置情報が含まれないため、長い文書では欠落箇所の特定が難しい（[#114](https://github.com/ynoki10/md2bl/issues/114)）。
+
+呼び出し側の回避策:
+
+- 山括弧を文字として残したいだけなら `&lt;` / `&gt;` で書く（`&lt;key&gt;` → `<key>`。警告も出ない）
+- コード表示にしてよいならインラインコードで囲む（`` `<key>` `` → `{code}<key>{/code}`）
+- 変換時に stderr の警告を確認し、出ていたら投稿前に本文を目視する
+
+### Unicode 絵文字は Backlog API に拒否される
+
+（2026-06-01 に実地確認）
+
+md2bl は Unicode 絵文字（`🙏` `✅` `⚠️` 等）を変換せずそのまま出力する。ただし Backlog API は課題・PR・コメントの本文でこれを受け付けず、投稿が次のエラーで失敗する。
+
+```
+Incorrect String: %F0%9F%99%8F...
+```
+
+4 バイト文字を格納できない列に当たっている挙動に見える。この制約は Backlog の公式ドキュメントには記載を見つけられていない。
+
+Backlog 絵文字記法（`:pray:` / `:white_check_mark:` / `:warning:` 等）は問題なく通る。呼び出し側で置換するか、変換対応（[#116](https://github.com/ynoki10/md2bl/issues/116)）を待つ。
+
 ## コード言語サポートについて
 
 Backlog記法の `{code:}` マクロがサポートする言語は **`java` と `cs`（C#）の2つのみ**。


### PR DESCRIPTION
## What changed / 変更内容

`docs/backlog-notation-gaps.md` の「既知の制限」に 2 セクションを追加しました。ドキュメントのみの変更で、実装は触っていません。

既存のこのドキュメントは Backlog公式ヘルプとの突き合わせ（調査日 2026-03-21）が中心で、「Markdown 側にはあるが Backlog に対応物がない・md2bl が落とす」方向の項目が一部載っていませんでした。呼び出し側が投稿前に把握できるよう、現在の挙動を事実ベースで追記しています。

### 1. 未対応ノードは警告つきで本文から除去される

変換できないノードに当たると stderr に警告が出て stdout の本文からは除去される、という共通の失敗モードを表にまとめました。

| 入力 | 関連 issue |
|---|---|
| プレーンテキスト中の `<...>` | #110 |
| HTML ブロック（内側のテキストも失われる） | #115 |
| `<br>`（GFM のテーブルセル内改行が表現できなくなる） | #112 |
| 参照リンク・参照画像（リンクテキスト・alt ごと失われる） | #111 |
| 脚注（注記の本文も失われる） | #113 |

あわせて、警告に入力の位置情報が含まれない点（#114）と、呼び出し側の回避策 3 点（`&lt;` / `&gt;` エスケープ、インラインコード、stderr の確認）を記載しました。

### 2. Unicode 絵文字は Backlog API に拒否される

md2bl は Unicode 絵文字を素通しする一方、Backlog API が `Incorrect String` で投稿を拒否するため、md2bl の出力をそのまま投稿すると失敗します。Backlog 絵文字記法への置換で回避できる旨と #116 へのリンクを記載しました。

## Related Issue / 関連 Issue

Refs #110, #111, #112, #113, #114, #115, #116

いずれも close はしません（このドキュメントは現状の挙動を記録するもので、各 issue の対応そのものではないため）。

## 補足

- 記載内容はすべて md2bl 0.4.2 を実際に実行して再現を確認しています（Node.js v24.14.1 / macOS arm64）
- 絵文字が Backlog API に拒否される挙動は 2026-06-01 に実地で確認したもので、Backlog の公式ドキュメントに記載を見つけられていません。その旨もドキュメント側に明記しています
- コードブロックの言語指定（`java` / `cs` のみ）は既存の記載どおり Backlog 側の制約なので、変更していません

## Checklist / チェックリスト

- [x] Tests pass (`pnpm test` — 123 tests passed)
- [x] Build passes (`pnpm run build`)
- [x] Commit messages follow Conventional Commits format

`pnpm run check`（biome + tsc）も指摘なしで通っています。
